### PR TITLE
Add top-level-menu, guides landing page.

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -35,11 +35,36 @@
   "get-started": {
     "title": "Create a Project"
   },
+  "documentation": {
+    "title": "Documentation",
+    "type": "menu",
+    "items": {
+      "configuration": {
+        "title": "Configuration",
+        "href": "/configuration"
+      },
+      "content": {
+        "title": "Adding Content",
+        "href": "/content"
+      },
+      "development": {
+        "title": "Development",
+        "href": "/development"
+      },
+      "guides": {
+        "title": "User Guides",
+        "href": "/guides"
+      }
+    }
+  },
   "about": {
     "title": "About",
     "type": "page"
   },
-  "contact": {
+  "guides": {
+    "display": "hidden"
+  },
+  "iiif": {
     "title": "What is IIIF? ↗",
     "type": "page",
     "href": "https://iiif.io/",

--- a/pages/guides.mdx
+++ b/pages/guides.mdx
@@ -1,0 +1,14 @@
+import { Cards, Card } from "nextra/components";
+
+# User Guides
+
+To get started with Canopy IIIF, check out the following guides that provide step-by-step instructions.
+
+<Cards>
+  <Card title="Create a Project" href="/get-started" />
+  <Card title="Create Markdown Content" href="/create-markdown-content" />
+  <Card title="Customize the Search Index" href="/customize-the-search-index" />
+  <Card title="Deploy to GitHub Pages" href="/deploy-to-github-pages" />
+  <Card title="Deploy to Vercel" href="/deploy-to-vercel" />
+  <Card title="Enable a Map with navPlace" href="/enable-a-map-with-navPlace" />
+</Cards>


### PR DESCRIPTION
This adds a top-level menu to the docs navigation, and an accompying `/guides` route as a landing page.

![image](https://github.com/canopy-iiif/docs/assets/7376450/68215ba5-e84d-4de0-ad15-31eef635c35e)
