### PR TITLE
Refine home styling.

### DIFF
--- a/components/Introduction.tsx
+++ b/components/Introduction.tsx
@@ -7,11 +7,29 @@ import React from "react";
 
 const Introduction = ({ heading, subHeading }) => {
   return (
-    <Section size="2" mb="5">
-      <Box style={{ width: "80%", minWidth: "400px" }}>
+    <Section
+      size={{
+        initial: "1",
+        sm: "2",
+      }}
+      mb="5"
+    >
+      <Box
+        mr={{
+          initial: "0",
+          sm: "9",
+        }}
+      >
         <Heading
-          size="9"
+          size={{
+            initial: "8",
+            sm: "9",
+          }}
           mb="3"
+          mr={{
+            initial: "0",
+            sm: "9",
+          }}
           weight="medium"
           style={{
             fontFamily: "var(--canopy-display-font)",
@@ -20,13 +38,31 @@ const Introduction = ({ heading, subHeading }) => {
         >
           <Balancer>{heading}</Balancer>
         </Heading>
-        <Flex direction="column" gap="2">
-          <Text size="5">
+        <Flex
+          direction="column"
+          gap="2"
+          mr={{
+            initial: "0",
+            sm: "9",
+          }}
+        >
+          <Text
+            size={{
+              initial: "4",
+              sm: "5",
+            }}
+          >
             <Balancer ratio={0.618}>{subHeading}</Balancer>
           </Text>
         </Flex>
         <Box pt="5">
-          <Flex gap="3">
+          <Flex
+            gap="3"
+            wrap={{
+              initial: "wrap",
+              sm: "nowrap",
+            }}
+          >
             <Link href="/get-started">
               <Button size="3">
                 Get Started

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -11,7 +11,7 @@ const Logo = () => (
       width="32"
       height="32"
     />
-    <span>Canopy IIIF</span>
+    <span style={{ whiteSpace: "nowrap" }}>Canopy IIIF</span>
     <style jsx>{`
       span {
         display: block;

--- a/components/Splash/Splash.tsx
+++ b/components/Splash/Splash.tsx
@@ -7,9 +7,26 @@ const Splash = ({ children }) => {
   const iiifContent = `/docs/iiif/francis-danby.json`;
 
   return (
-    <Section size="3">
-      <Box style={{ position: "relative" }}>
-        <Box>{children}</Box>
+    <Section size="1">
+      <Box style={{ position: "relative" }} mt="5">
+        <Box style={{ position: "relative" }}>
+          <Box
+            style={{
+              maskImage: "linear-gradient(0deg, #0000 100px, #000 300px)",
+            }}
+          >
+            {children}
+          </Box>
+          <Box
+            style={{
+              position: "absolute",
+              zIndex: "1",
+              height: "100%",
+              width: "100%",
+              bottom: "0",
+            }}
+          ></Box>
+        </Box>
         <Window iiifContent={iiifContent} />
       </Box>
     </Section>

--- a/components/Splash/Window.tsx
+++ b/components/Splash/Window.tsx
@@ -32,6 +32,7 @@ const SplashWindow = ({ iiifContent }) => {
         top: "-50px",
         overflow: "hidden",
         left: "50%",
+        zIndex: "2",
       }}
     >
       <Box

--- a/pages/enable-a-map-with-navPlace.mdx
+++ b/pages/enable-a-map-with-navPlace.mdx
@@ -36,7 +36,7 @@ import { Box, Text, Section } from "@radix-ui/themes";
 
 ### Create a new Canopy IIIF Project
 
-Select a IIIF Collection with geospatial point data and configured a Canopy IIIF project. In this example we will use the [William Cox Cochran Photograph](https://digital.lib.utk.edu/assemble/collection/gsmrc/wcc) IIIF Collection.
+Select a IIIF Collection with geospatial point data and configure a Canopy IIIF project. In this example we will use the [William Cox Cochran Photograph](https://digital.lib.utk.edu/assemble/collection/gsmrc/wcc) IIIF Collection.
 
 ```json filename="config/canopy.json" copy
 {

--- a/pages/features/_meta.json
+++ b/pages/features/_meta.json
@@ -5,13 +5,7 @@
     }
   },
   "home": "Home",
-<<<<<<< HEAD
   "search": "Search",
   "works": "Works",
   "metadata": "Metadata"
-=======
-  "metadata": "Metadata",
-  "search": "Search",
-  "works": "Works"
->>>>>>> 19feae8 (Updates to Getting Started and Deploy Guides)
 }

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -44,7 +44,14 @@ import {
         "label": {
           "en": ["A View across the Artist's Garden from his House at Exmouth, Devonshire"]
         }
-      }
+      },
+      {
+        "id": "https://manifests.collections.yale.edu/ycba/obj/710",
+        "type": "Manifest",
+        "label": {
+          "en": ["Shipwreck"]
+        },
+      },
     ]
   }
 ```
@@ -52,8 +59,8 @@ import {
 
 <Section size="2">
   <Container size="3">
-    <Flex gap="9">
-      <Box>
+    <Flex gap="9" direction={{ initial: "column", sm: "row"} }>
+      <Box style={{minWidth: "40%"}}>
         <Heading size="7" mb="5" weight="regular" style={{ fontFamily: "var(--canopy-display-font)" }}>
           What is Canopy IIIF?
         </Heading>
@@ -67,7 +74,7 @@ import {
         </Text>
 
       </Box>
-      <Box style={{width: "50%"}} shrink="0">
+      <Box style={{minWidth: "40%"}} shrink="0">
         <Heading
           size="7"
           mb="5"
@@ -109,7 +116,7 @@ import {
       padding: "2rem",
       borderRadius: "0.5rem",
       borderTop: "4px solid var(--accent-3)",
-      width: "33.333%",
+      minWidth: "33.333%",
     }}
     grow={0}
     shrink={0}
@@ -128,7 +135,7 @@ import {
       padding: "2rem",
       borderRadius: "0.5rem",
       borderTop: "4px solid var(--accent-3)",
-      width: "33.333%",
+      minWidth: "33.333%",
     }}
     grow={0}
     shrink={0}
@@ -146,7 +153,7 @@ import {
       padding: "2rem",
       borderRadius: "0.5rem",
       borderTop: "4px solid var(--accent-3)",
-      width: "33.333%",
+      minWidth: "33.333%",
     }}
   >
     <Heading size="5" mb="3" weight="regular" color="indigo">

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -54,7 +54,7 @@ const config: DocsThemeConfig = {
   footer: {
     text: <Footer description={siteDescription} />,
   },
-  darkMode: false,
+  darkMode: true,
   gitTimestamp: null,
   nextThemes: {
     defaultTheme: "light",


### PR DESCRIPTION
This work mainly refines some responsiveness issues on the homepage.

- Adds responsiveness to the intro text so its not so glaringly large in smaller viewports
- Allows wrapping of buttons in splash
- Disallows wrapping of title text in the header
- Adds a mask to the code snippet for the IIIF Collection in the splash making it smoothly fade out
- Adds flex direction responsiveness to text boxes below the splash
- Allows dark mode toggle in footer