### PR TITLE
Document Google Analytics and Google Tag Manager.

### DIFF
--- a/pages/configuration/vendor.mdx
+++ b/pages/configuration/vendor.mdx
@@ -1,0 +1,33 @@
+# Vendor Configuration
+
+The `vendor` property is optional and provides a way to add custom vendor scripts and customized components used within a Canopy IIIF project.
+
+## Google
+
+The `vendor` property can be used to add Google Analytics or Google Tag Manager to your Canopy project. The `googleAnalytics` and `googleTagManager` properties are optional and can be added to the `vendor` object in the `config/canopy.json` file.
+
+### Google Tag Manager
+
+```json filename="config/canopy.json" copy {4-6}
+{
+  "collection": "https://iiif.io/api/cookbook/recipe/0032-collection/collection.json",
+  "vendor": {
+    "googleTagManager": {
+      "gtmId": "GTM-XXXXXXXX"
+    }
+  }
+}
+```
+
+### Google Analytics
+
+```json filename="config/canopy.json" copy {4-6}
+{
+  "collection": "https://iiif.io/api/cookbook/recipe/0032-collection/collection.json",
+  "vendor": {
+    "googleAnalytics": {
+      "gaId": "G-XXXXXXXXXX"
+    }
+  }
+}
+```

--- a/pages/development.mdx
+++ b/pages/development.mdx
@@ -66,3 +66,7 @@ To avoid potential code conflicts on future release updates, it is advised not t
 </FileTree>
 
 **Note:** Future considerations will be delivered upon for updating content within these pages.
+
+## Analytics and Tracking
+
+Canopy provides a way to add Google Analytics or Google Tag Manager to your project. The `vendor` property is optional and can be added to the `config/canopy.json` file. Read more about [Vendor Configuration](/configuration/vendor#google).


### PR DESCRIPTION
This initializes the Vendor docs page and adds a section for Google third party GA and GTM configuration. 

![image](https://github.com/user-attachments/assets/53b0b759-6971-40d9-be35-a3bcbfd6fdbb)
